### PR TITLE
Use full path to sysctl on FreeBSD

### DIFF
--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -31,7 +31,7 @@ fn get_os() -> Type {
 
     match str::from_utf8(&os.stdout) {
         Ok("FreeBSD\n") => {
-            let check_hardening = Command::new("sysctl")
+            let check_hardening = Command::new("/sbin/sysctl")
                 .arg("hardening.version")
                 .output()
                 .expect("Failed to check if is hardened");


### PR DESCRIPTION
Calling get_os on FreeBSD without `/sbin/` in your $PATH causes a panic:

```
thread 'main' panicked at /rust/deps/os_info-3.7.0/src/freebsd/mod.rs:37:18:
Failed to check if is hardened: Os { code: 2, kind: NotFound, message: "No such file or directory" }
stack backtrace:
   0: rust_begin_unwind
             at /rustc/e51e98dde6a60637b6a71b8105245b629ac3fe77/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/e51e98dde6a60637b6a71b8105245b629ac3fe77/library/core/src/panicking.rs:72:14
   2: core::result::unwrap_failed
             at /rustc/e51e98dde6a60637b6a71b8105245b629ac3fe77/library/core/src/result.rs:1649:5
   3: os_info::imp::current_platform
   4: os_info::get
...
```

Call the binary with a full path instead.

Tested on FreeBSD 13.1.